### PR TITLE
Bug with many two dispatch functions in one time.

### DIFF
--- a/app/src/main/java/com/bogdan/codeforceswatcher/CwApplication.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/CwApplication.kt
@@ -21,7 +21,7 @@ val store = Store(
     reducer = ::appReducer,
     state = RoomController.fetchAppState(),
     middleware = listOf(
-        appMiddleware, notificationMiddleware, toastMiddleware
+        notificationMiddleware, toastMiddleware, appMiddleware
     )
 )
 

--- a/app/src/main/java/com/bogdan/codeforceswatcher/features/users/UsersFragment.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/features/users/UsersFragment.kt
@@ -52,6 +52,8 @@ class UsersFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener,
     override fun newState(state: UsersState) {
         swipeRefreshLayout.isRefreshing = (state.status == UsersState.Status.PENDING)
         usersAdapter.setItems(state.users.sort(state.sortType).map { UserItem.User(it) })
+        println("newState : ${state.users}")
+        println("status : ${state.status}")
         adjustSpinnerSortVisibility(state.users.isEmpty())
     }
 

--- a/app/src/main/java/com/bogdan/codeforceswatcher/features/users/redux/reducers/UsersReducer.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/features/users/redux/reducers/UsersReducer.kt
@@ -9,20 +9,23 @@ import org.rekotlin.Action
 
 fun usersReducer(action: Action, state: AppState): UsersState {
     var newState = state.users
-
+    println("usersReducer is working")
     when (action) {
         is UsersRequests.FetchUsers -> {
+            println("reducer continue")
             newState = newState.copy(
                 status = UsersState.Status.PENDING
             )
         }
         is UsersRequests.FetchUsers.Success -> {
+            println("reducer success")
             newState = newState.copy(
                 status = UsersState.Status.IDLE,
                 users = action.users
             )
         }
         is UsersRequests.FetchUsers.Failure -> {
+            println("reducer failure stop")
             newState = newState.copy(
                 status = UsersState.Status.IDLE
             )

--- a/app/src/main/java/com/bogdan/codeforceswatcher/features/users/redux/requests/UsersRequests.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/features/users/redux/requests/UsersRequests.kt
@@ -10,6 +10,10 @@ import com.bogdan.codeforceswatcher.redux.Request
 import com.bogdan.codeforceswatcher.redux.actions.ToastAction
 import com.bogdan.codeforceswatcher.room.DatabaseClient
 import com.bogdan.codeforceswatcher.store
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.rekotlin.Action
 
 enum class Source(val isToastNeeded: Boolean) {
@@ -25,17 +29,22 @@ class UsersRequests {
         override fun execute() {
             val users: List<User> = DatabaseClient.userDao.getAll()
             getUsers(getHandles(users), true) { result ->
-                when (result) {
-                    is UsersRequestResult.Failure -> dispatchError(result.error)
-                    is UsersRequestResult.Success ->
-                        store.dispatch(
-                            Success(result.users, getDifferenceAndUpdate(users, result.users), source)
-                        )
-                }
+                println("getUsers: status : ${store.state.users.status}")
+                println("getUsers: result : $result")
+                //GlobalScope.launch(Dispatchers.Main) {
+                    when (result) {
+                        is UsersRequestResult.Failure -> dispatchError(result.error)
+                        is UsersRequestResult.Success ->
+                            store.dispatch(
+                                Success(result.users, getDifferenceAndUpdate(users, result.users), source)
+                            )
+                    }
+                //}
             }
         }
 
         private fun dispatchError(error: Error) {
+            println("dispatch : error")
             val noConnectionError = CwApp.app.resources.getString(R.string.no_connection)
             val fetchingUsersError = CwApp.app.resources.getString(R.string.failed_to_fetch_users)
 

--- a/app/src/main/java/com/bogdan/codeforceswatcher/network/CodeforcesApi.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/network/CodeforcesApi.kt
@@ -5,6 +5,7 @@ import com.bogdan.codeforceswatcher.features.contests.redux.requests.ContestsRes
 import com.bogdan.codeforceswatcher.features.users.redux.requests.RatingChangeResponse
 import com.bogdan.codeforceswatcher.features.users.redux.requests.UsersResponse
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -14,7 +15,7 @@ interface CodeforcesApi {
     fun getRating(@Query("handle") handle: String): Call<RatingChangeResponse>
 
     @GET("user.info")
-    fun getUsers(@Query("handles") handles: String): Call<UsersResponse>
+    suspend fun getUsers(@Query("handles") handles: String): Response<UsersResponse>
 
     @GET("contest.list")
     fun getContests(): Call<ContestsResponse>

--- a/app/src/main/java/com/bogdan/codeforceswatcher/network/RestClient.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/network/RestClient.kt
@@ -28,7 +28,7 @@ object RestClient {
 
     private val codeforcesApi by lazy { retrofit.create(CodeforcesApi::class.java) }
 
-    fun getUsers(handle: String) = codeforcesApi.getUsers(handle)
+    suspend fun getUsers(handle: String) = codeforcesApi.getUsers(handle)
 
     fun getRating(handle: String) = codeforcesApi.getRating(handle)
 

--- a/app/src/main/java/com/bogdan/codeforceswatcher/network/UsersRequest.kt
+++ b/app/src/main/java/com/bogdan/codeforceswatcher/network/UsersRequest.kt
@@ -1,65 +1,47 @@
 package com.bogdan.codeforceswatcher.network
 
 import com.bogdan.codeforceswatcher.features.users.models.User
-import com.bogdan.codeforceswatcher.features.users.redux.requests.RatingChangeResponse
-import com.bogdan.codeforceswatcher.features.users.redux.requests.UsersResponse
 import com.bogdan.codeforceswatcher.network.models.Error
 import com.bogdan.codeforceswatcher.network.models.UsersRequestResult
-import kotlinx.coroutines.*
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 fun getUsers(handles: String, isRatingUpdatesNeeded: Boolean, onCompleted: (UsersRequestResult) -> Unit) {
-    val userCall = RestClient.getUsers(handles)
-    userCall.enqueue(object : Callback<UsersResponse> {
-
-        override fun onResponse(call: Call<UsersResponse>, response: Response<UsersResponse>) {
+    onCompleted(UsersRequestResult.Failure(Error.INTERNET))
+    /*GlobalScope.launch {
+        try {
+            val response = RestClient.getUsers(handles)
             response.body()?.users?.let { users ->
                 if (isRatingUpdatesNeeded) {
-                    loadRatingUpdates(users, onCompleted)
+                    onCompleted(loadRatingUpdates(users))
                 } else {
                     onCompleted(UsersRequestResult.Success(users))
                 }
             } ?: onCompleted(UsersRequestResult.Failure(Error.RESPONSE))
-        }
-
-        override fun onFailure(call: Call<UsersResponse>, t: Throwable) {
+        } catch (t: Throwable) {
             onCompleted(UsersRequestResult.Failure(Error.INTERNET))
         }
-    })
+    }*/
 }
 
-private fun loadRatingUpdates(
-    userList: List<User>,
-    onCompleted: (UsersRequestResult) -> Unit
-) {
-    Thread {
-        var countFetchedUsers = 0
-        for (user in userList) {
-            Thread.sleep(250) // Because Codeforces blocks frequent queries
-            val response = try {
-                RestClient.getRating(user.handle).execute()
-            } catch (error: java.net.SocketTimeoutException) {
-                null
-            }
-            response?.body()?.ratingChanges?.let { ratingChanges ->
-                user.ratingChanges = ratingChanges
-            } ?: break
-            countFetchedUsers++
+suspend fun loadRatingUpdates(userList: List<User>): UsersRequestResult {
+    var countFetchedUsers = 0
+    for (user in userList) {
+        delay(250) // Because Codeforces blocks frequent queries
+        val response = try {
+            RestClient.getRating(user.handle).execute()
+        } catch (error: java.net.SocketTimeoutException) {
+            null
         }
-        returnResultOnMainThread(if (countFetchedUsers < userList.size) {
-            UsersRequestResult.Failure(Error.RESPONSE)
-        } else {
-            UsersRequestResult.Success(userList)
-        }, onCompleted)
-    }.start()
-}
-
-private fun returnResultOnMainThread(result: UsersRequestResult, onCompleted: (UsersRequestResult) -> Unit) {
-    runBlocking {
-        withContext(Dispatchers.Main) {
-            onCompleted(result)
-        }
+        response?.body()?.ratingChanges?.let { ratingChanges ->
+            user.ratingChanges = ratingChanges
+        } ?: break
+        countFetchedUsers++
+    }
+    return if (countFetchedUsers < userList.size) {
+        UsersRequestResult.Failure(Error.RESPONSE)
+    } else {
+        UsersRequestResult.Success(userList)
     }
 }


### PR DESCRIPTION
You can easily reproduce this bug:
- open users tab and see how spinner flail all time

(It's because UsersRequest.FetchUsers in UsersReducer calls only after UsersRequest.FetchUsers.Failure -> `status = PENDING` occurs after `status = IDLE`).